### PR TITLE
Revise symlinks docs: downgrade to option with caveats

### DIFF
--- a/src/content/docs/commands.md
+++ b/src/content/docs/commands.md
@@ -68,16 +68,44 @@ Use the recommended template in the [documentation-spec](../../skills/documentat
 
 From here, every team member uses **slash-command at-artifact** (e.g. `/write-spec @docs/stories/submit-sales-order.md`). For multi-step orchestration, see the Workflows page.
 
-## The Symlink Approach
+## Sharing Commands Across IDEs
 
-Both **commands** and **workflows** are stored in `.claude/commands/`. Each IDE looks in a different folder. Use symlinks so that one canonical location works everywhere.
+Both **commands** and **workflows** are stored in `.claude/commands/`. Each IDE looks in a different folder. Use one of the strategies below so that one canonical location works everywhere.
 
-**Option A - Use the factory-engineering skill:** Install with `npx openskills install factoryengineering/skills`, then ask your agent to create symlinks for your selected IDEs. The skill sets up symlinks for **commands/workflows** (`.claude/commands/`) and **skills** (`.claude/skills/`) in one go (or use `--type commands` to do only commands). The agent can **detect** which IDEs you have (e.g. run the script with `--detect`), confirm with you, then create symlinks. If a target folder already exists (e.g. `.cursor/commands`), the skill will **offer to copy** its contents into the canonical folder and then replace it with a symlink (`--copy-existing`). On **Windows**, use the skill's PowerShell script (`Setup-Symlinks.ps1`).
+### Strategy 1 — Copy-on-Change (recommended for most teams)
 
-**Option B - Create symlinks manually for each IDE:** Run these from your **repository root**. The symlink target `../.claude/commands` is resolved relative to the link's directory (e.g. `.cursor/`), so it correctly points at the repo's `.claude/commands/`.
+Keep canonical commands in `.claude/commands/` and copy them into each IDE's expected folder when they change. This works on every OS and avoids symlink caveats (see Strategy 3).
 
 ```bash
-# Cursor
+# Example: copy commands into each IDE folder after a change
+for pair in ".cursor/commands" ".windsurf/workflows" ".kilocode/workflows" ".agent/workflows"; do
+  mkdir -p "$(dirname "$pair")"
+  cp -R .claude/commands "$pair"
+done
+```
+
+Automate this with a Git hook, file watcher, or CI step so copies never drift. Commit the copied folders.
+
+### Strategy 2 — IDE-Native Locations Only
+
+Store commands directly in each IDE's folder and skip the canonical location. Simple for one or two IDEs, but maintenance grows with IDE count.
+
+### Strategy 3 — Symlinks (macOS/Linux only, with caveats)
+
+Symlinks avoid file duplication but have significant limitations:
+
+- **Windows:** Requires Developer Mode or administrator privileges (often restricted in corporate environments). Symlinks created on macOS/Linux may not resolve when cloned on Windows.
+- **Cursor:** Cursor's file watcher does not properly follow directory symlinks. Use copy-on-change or place commands directly in `.cursor/commands/`.
+- **IDE inconsistencies:** Some IDEs watch symlink targets correctly; others watch the symlink itself or skip watching entirely.
+
+If your team is macOS/Linux-only and does not use Cursor, symlinks remain viable:
+
+**Option A — Use the factory-engineering skill:** Install with `npx openskills install factoryengineering/skills`, then ask your agent to create symlinks for your selected IDEs. The skill sets up symlinks for **commands/workflows** (`.claude/commands/`) and **skills** (`.claude/skills/`) in one go (or use `--type commands` to do only commands). The agent can **detect** which IDEs you have (e.g. run the script with `--detect`), confirm with you, then create symlinks. If a target folder already exists (e.g. `.cursor/commands`), the skill will **offer to copy** its contents into the canonical folder and then replace it with a symlink (`--copy-existing`). On **Windows**, use the skill's PowerShell script (`Setup-Symlinks.ps1`).
+
+**Option B — Create symlinks manually for each IDE:** Run these from your **repository root**. The symlink target `../.claude/commands` is resolved relative to the link's directory (e.g. `.cursor/`), so it correctly points at the repo's `.claude/commands/`.
+
+```bash
+# Cursor (prefer copy-on-change — see caveats above)
 mkdir -p .cursor
 ln -s ../.claude/commands .cursor/commands
 
@@ -94,23 +122,23 @@ mkdir -p .agent
 ln -s ../.claude/commands .agent/workflows
 ```
 
-Commit the symlinks so every team member gets the correct structure on clone.
+Commit the symlinks so every team member on macOS/Linux gets the correct structure on clone.
 
-**GitHub Copilot (VS Code)** uses prompt files (`.prompt.md`) with different naming and optional frontmatter, so commands cannot be shared via symlinks. Use a **sync** step instead; the **factory-engineering** skill includes sync instructions and a batch script (see [GitHub Copilot (VS Code)](#github-copilot-vs-code) below).
+**GitHub Copilot (VS Code)** uses prompt files (`.prompt.md`) with different naming and optional frontmatter, so commands cannot be shared via symlinks or simple copies. Use a **sync** step instead; the **factory-engineering** skill includes sync instructions and a batch script (see [GitHub Copilot (VS Code)](#github-copilot-vs-code) below).
 
-Stored in `.claude/commands/`, this file is available as `/write-design` in Claude Code and Cursor; with symlinks, the same file is used by Windsurf, Kilo Code, and Antigravity. Invoke with **slash-command at-artifact** (e.g. `/write-design @docs/user-stories/billing-email.md`).
+Stored in `.claude/commands/`, this file is available as `/write-design` in Claude Code and Cursor; with copy-on-change or symlinks, the same file is used by Windsurf, Kilo Code, and Antigravity. Invoke with **slash-command at-artifact** (e.g. `/write-design @docs/user-stories/billing-email.md`).
 
 ## IDE-by-IDE Reference
 
 All IDEs support commands, but they use different folder locations, invocation patterns, and terminology. The table below summarizes the key differences. For full setup details, see each IDE's dedicated page.
 
-| IDE | Folder | Invocation | Symlink Needed? | Details |
-|-----|--------|------------|-----------------|---------|
+| IDE | Folder | Invocation | Sharing Required? | Details |
+|-----|--------|------------|-------------------|---------|
 | [Claude Code](/ides/claude-code) | `.claude/commands/` | `/command-name` | No (canonical location) | [Full setup →](/ides/claude-code#commands) |
-| [Cursor](/ides/cursor) | `.cursor/commands/` | `/command-name` | ✅ Yes | [Full setup →](/ides/cursor#commands) |
-| [Windsurf](/ides/windsurf) | `.windsurf/workflows/` | `/workflow-name` | ✅ Yes | [Full setup →](/ides/windsurf#commands) |
-| [Kilo Code](/ides/kilo-code) | `.kilocode/workflows/` | `/workflow-name` | ✅ Yes | [Full setup →](/ides/kilo-code#commands) |
-| [Google Antigravity](/ides/google-antigravity) | `.agent/workflows/` | `/workflow-name` | ✅ Yes | [Full setup →](/ides/google-antigravity#commands) |
+| [Cursor](/ides/cursor) | `.cursor/commands/` | `/command-name` | ✅ Yes (copy or symlink) | [Full setup →](/ides/cursor#commands) |
+| [Windsurf](/ides/windsurf) | `.windsurf/workflows/` | `/workflow-name` | ✅ Yes (copy or symlink) | [Full setup →](/ides/windsurf#commands) |
+| [Kilo Code](/ides/kilo-code) | `.kilocode/workflows/` | `/workflow-name` | ✅ Yes (copy or symlink) | [Full setup →](/ides/kilo-code#commands) |
+| [Google Antigravity](/ides/google-antigravity) | `.agent/workflows/` | `/workflow-name` | ✅ Yes (copy or symlink) | [Full setup →](/ides/google-antigravity#commands) |
 | [GitHub Copilot](/ides/github-copilot) | `.github/prompts/` | `/prompt-name` | Sync (not symlink) | [Full setup →](/ides/github-copilot#commands) |
 | [OpenAI Codex](/ides/openai-codex) | `.agents/skills/` (via skills) | `$skill-name` | ⚠️ Needs investigation (use skills) | [Full setup →](/ides/openai-codex#commands) |
 

--- a/src/content/docs/commands.md
+++ b/src/content/docs/commands.md
@@ -72,19 +72,31 @@ From here, every team member uses **slash-command at-artifact** (e.g. `/write-sp
 
 Both **commands** and **workflows** are stored in `.claude/commands/`. Each IDE looks in a different folder. Use one of the strategies below so that one canonical location works everywhere.
 
-### Strategy 1 — Copy-on-Change (recommended for most teams)
+### Strategy 1 — Sync with rsync (recommended for most teams)
 
-Keep canonical commands in `.claude/commands/` and copy them into each IDE's expected folder when they change. This works on every OS and avoids symlink caveats (see Strategy 3).
+Keep canonical commands in `.claude/commands/` and use a two-step `rsync` to keep every IDE folder in sync. This works on every OS and avoids symlink caveats (see Strategy 3). The two-step pattern gathers changes from non-canonical locations first, so a developer who edits in `.kilocode/workflows/` does not lose work when the sync runs.
 
 ```bash
-# Example: copy commands into each IDE folder after a change
-for dest in ".cursor/commands" ".windsurf/workflows" ".kilocode/workflows" ".agent/workflows"; do
+#!/usr/bin/env bash
+# sync-commands.sh — run from repo root
+
+IDE_COMMANDS=(.cursor/commands .windsurf/workflows .kilocode/workflows .agent/workflows)
+
+# Step 1: reverse-sync — gather changes from any IDE location back to canonical
+for src in "${IDE_COMMANDS[@]}"; do
+  [ -d "$src" ] && rsync -a "$src/" .claude/commands/
+done
+
+# Step 2: forward-sync — mirror canonical to all IDE locations
+for dest in "${IDE_COMMANDS[@]}"; do
   mkdir -p "$dest"
-  cp -R .claude/commands/. "$dest"/
+  rsync -a --delete .claude/commands/ "$dest"/
 done
 ```
 
-Automate this with a Git hook, file watcher, or CI step so copies never drift. Commit the copied folders.
+**Step 1** is additive (no `--delete`): new or modified files in any IDE folder are copied back to `.claude/commands/`. **Step 2** uses `--delete` so each destination becomes an exact mirror of canonical.
+
+Automate this with a Git hook, file watcher, or CI step so copies never drift. Commit the synced folders.
 
 ### Strategy 2 — IDE-Native Locations Only
 

--- a/src/content/docs/commands.md
+++ b/src/content/docs/commands.md
@@ -17,7 +17,7 @@ Like skills, commands must live in your project repository and evolve with your 
 
 ## Example command file
 
-Commands are markdown files. The slash name is the filename without `.md` (e.g. `write-design.md` → `/write-design`). This is a convention shared across IDEs; folder locations vary (see table below). Because commands are shared via symlinks, keep them **IDE-agnostic**: do not rely on `$ARGUMENTS` or other placeholders, since not all IDEs support them. Instead, write the command so it **states what the user will supply** (e.g. a user story or design document, by link or by name) and **instructs the LLM to stop and prompt the user** if that input is missing. That pattern works consistently in every IDE. Below is an example showing this pattern plus location, purpose, structure, and a short checklist.
+Commands are markdown files. The slash name is the filename without `.md` (e.g. `write-design.md` → `/write-design`). This is a convention shared across IDEs; folder locations vary (see table below). Because commands are shared across IDEs (via rsync or symlinks), keep them **IDE-agnostic**: do not rely on `$ARGUMENTS` or other placeholders, since not all IDEs support them. Instead, write the command so it **states what the user will supply** (e.g. a user story or design document, by link or by name) and **instructs the LLM to stop and prompt the user** if that input is missing. That pattern works consistently in every IDE. Below is an example showing this pattern plus location, purpose, structure, and a short checklist.
 
 **Example (`.claude/commands/write-design.md`):**
 
@@ -82,6 +82,9 @@ Keep canonical commands in `.claude/commands/` and use a two-step `rsync` to kee
 
 IDE_COMMANDS=(.cursor/commands .windsurf/workflows .kilocode/workflows .agent/workflows)
 
+# Ensure canonical directory exists (first-time setup)
+mkdir -p .claude/commands
+
 # Step 1: reverse-sync — gather changes from any IDE location back to canonical
 for src in "${IDE_COMMANDS[@]}"; do
   [ -d "$src" ] && rsync -a "$src/" .claude/commands/
@@ -136,9 +139,9 @@ ln -s ../.claude/commands .agent/workflows
 
 Commit the symlinks so every team member on macOS/Linux gets the correct structure on clone.
 
-**GitHub Copilot (VS Code)** uses prompt files (`.prompt.md`) with different naming and optional frontmatter, so commands cannot be shared via symlinks or simple copies. Use a **sync** step instead; the **factory-engineering** skill includes sync instructions and a batch script (see [GitHub Copilot (VS Code)](#github-copilot-vs-code) below).
+**GitHub Copilot (VS Code)** uses prompt files (`.prompt.md`) with different naming and optional frontmatter, so commands cannot be shared via rsync or symlinks. Use a **format-aware sync** step instead; the **factory-engineering** skill includes sync instructions and a batch script (see [GitHub Copilot (VS Code)](#github-copilot-vs-code) below).
 
-Stored in `.claude/commands/`, this file is available as `/write-design` in Claude Code and Cursor; with copy-on-change or symlinks, the same file is used by Windsurf, Kilo Code, and Antigravity. Invoke with **slash-command at-artifact** (e.g. `/write-design @docs/user-stories/billing-email.md`).
+Stored in `.claude/commands/`, this file is available as `/write-design` in Claude Code and Cursor; with rsync or symlinks, the same file is used by Windsurf, Kilo Code, and Antigravity. Invoke with **slash-command at-artifact** (e.g. `/write-design @docs/user-stories/billing-email.md`).
 
 ## IDE-by-IDE Reference
 

--- a/src/content/docs/commands.md
+++ b/src/content/docs/commands.md
@@ -78,9 +78,9 @@ Keep canonical commands in `.claude/commands/` and copy them into each IDE's exp
 
 ```bash
 # Example: copy commands into each IDE folder after a change
-for pair in ".cursor/commands" ".windsurf/workflows" ".kilocode/workflows" ".agent/workflows"; do
-  mkdir -p "$(dirname "$pair")"
-  cp -R .claude/commands "$pair"
+for dest in ".cursor/commands" ".windsurf/workflows" ".kilocode/workflows" ".agent/workflows"; do
+  mkdir -p "$dest"
+  cp -R .claude/commands/. "$dest"/
 done
 ```
 

--- a/src/content/docs/ides.md
+++ b/src/content/docs/ides.md
@@ -18,10 +18,10 @@ Choose your IDE below for a dedicated guide covering everything you need to set 
 | [Claude Code](/ides/claude-code) | ✅ Native | ✅ `/command` | ✅ Sub-agents | ✅ Full orchestration | [→ Guide](/ides/claude-code) |
 | [GitHub Copilot](/ides/github-copilot) | ✅ Native | ✅ `/command` | ✅ Custom agents | ⚠️ Partial (Fleet mode) | [→ Guide](/ides/github-copilot) |
 | [Cursor](/ides/cursor) | ✅ Native | ✅ `/command` | ✅ Subagents | ⚠️ Partial (subagent delegation) | [→ Guide](/ides/cursor) |
-| [Windsurf](/ides/windsurf) | ✅ Via symlink | ✅ `/workflow` | ❌ No | ❌ No | [→ Guide](/ides/windsurf) |
+| [Windsurf](/ides/windsurf) | ✅ Via copy or symlink | ✅ `/workflow` | ❌ No | ❌ No | [→ Guide](/ides/windsurf) |
 | [Kilo Code](/ides/kilo-code) | ✅ Native | ✅ `/workflow` | ✅ Modes | ✅ Orchestrator Mode | [→ Guide](/ides/kilo-code) |
-| [Google Antigravity](/ides/google-antigravity) | ✅ Via symlink | ✅ `/workflow` | ✅ AgentKit 2.0 | ⚠️ Partial (Manager View) | [→ Guide](/ides/google-antigravity) |
-| [OpenAI Codex](/ides/openai-codex) | ✅ Via symlink | ⚠️ Needs investigation (`$skill-name`) | ⚠️ Custom agents (TOML) | ⚠️ Partial (sub-agent delegation) | [→ Guide](/ides/openai-codex) |
+| [Google Antigravity](/ides/google-antigravity) | ✅ Via copy or symlink | ✅ `/workflow` | ✅ AgentKit 2.0 | ⚠️ Partial (Manager View) | [→ Guide](/ides/google-antigravity) |
+| [OpenAI Codex](/ides/openai-codex) | ✅ Via copy or symlink | ⚠️ Needs investigation (`$skill-name`) | ⚠️ Custom agents (TOML) | ⚠️ Partial (sub-agent delegation) | [→ Guide](/ides/openai-codex) |
 
 ---
 
@@ -30,7 +30,7 @@ Choose your IDE below for a dedicated guide covering everything you need to set 
 Each IDE guide is structured with the same sections:
 
 - **Overview** — what the IDE is and how it fits into factory engineering
-- **Skills** — folder locations, setup, symlink needs
+- **Skills** — folder locations, setup, sharing strategies (copy-on-change, symlinks)
 - **Commands** — folder location, invocation pattern, format notes
 - **Agents** — support status, feature name, storage, memory capability
 - **Workflows** — orchestration support and notes

--- a/src/content/docs/ides/cursor.md
+++ b/src/content/docs/ides/cursor.md
@@ -42,11 +42,23 @@ For more about how skills work in factory engineering, see [Skills](/skills).
 /write-spec @submit-sales-order
 ```
 
-Since Cursor uses `.cursor/commands/` and the canonical commands live in `.claude/commands/`, create a symlink:
+Since Cursor uses `.cursor/commands/` and the canonical commands live in `.claude/commands/`, you need to share them. **Copy-on-change is recommended** — Cursor's file watcher does not properly follow directory symlinks, which can cause commands to appear stale or missing until you restart the editor.
+
+**Copy-on-change (recommended):**
+
+```bash
+cp -R .claude/commands .cursor/commands
+```
+
+Automate this with a Git hook or file watcher so copies stay in sync.
+
+**Symlink (not recommended for Cursor):**
 
 ```bash
 ln -s ../.claude/commands .cursor/commands
 ```
+
+If you use a symlink, be aware that Cursor may not detect changes to files inside the symlinked directory. You may need to restart Cursor or reload the window after modifying commands.
 
 **Built-in commands (v3.0):** Cursor 3 added `/worktree` (creates an isolated git worktree so agents work without conflicts) and `/best-of-n` (runs the same prompt across multiple models in parallel worktrees and compares results). These are built-in commands, not user-defined — your custom commands in `.cursor/commands/` continue to work alongside them.
 

--- a/src/content/docs/ides/cursor.md
+++ b/src/content/docs/ides/cursor.md
@@ -47,7 +47,8 @@ Since Cursor uses `.cursor/commands/` and the canonical commands live in `.claud
 **Copy-on-change (recommended):**
 
 ```bash
-cp -R .claude/commands .cursor/commands
+mkdir -p .cursor/commands
+cp -R .claude/commands/. .cursor/commands/
 ```
 
 Automate this with a Git hook or file watcher so copies stay in sync.

--- a/src/content/docs/ides/cursor.md
+++ b/src/content/docs/ides/cursor.md
@@ -48,7 +48,8 @@ Since Cursor uses `.cursor/commands/` and the canonical commands live in `.claud
 
 ```bash
 # Gather any local changes back to canonical, then mirror
-rsync -a .cursor/commands/ .claude/commands/
+mkdir -p .claude/commands
+[ -d .cursor/commands ] && rsync -a .cursor/commands/ .claude/commands/
 mkdir -p .cursor/commands
 rsync -a --delete .claude/commands/ .cursor/commands/
 ```

--- a/src/content/docs/ides/cursor.md
+++ b/src/content/docs/ides/cursor.md
@@ -44,14 +44,16 @@ For more about how skills work in factory engineering, see [Skills](/skills).
 
 Since Cursor uses `.cursor/commands/` and the canonical commands live in `.claude/commands/`, you need to share them. **Copy-on-change is recommended** — Cursor's file watcher does not properly follow directory symlinks, which can cause commands to appear stale or missing until you restart the editor.
 
-**Copy-on-change (recommended):**
+**Rsync (recommended):**
 
 ```bash
+# Gather any local changes back to canonical, then mirror
+rsync -a .cursor/commands/ .claude/commands/
 mkdir -p .cursor/commands
-cp -R .claude/commands/. .cursor/commands/
+rsync -a --delete .claude/commands/ .cursor/commands/
 ```
 
-Automate this with a Git hook or file watcher so copies stay in sync.
+Automate this with a Git hook or file watcher so copies stay in sync. See [Commands — Sync with rsync](/commands#strategy-1--sync-with-rsync-recommended-for-most-teams) for the full two-step pattern covering all IDEs.
 
 **Symlink (not recommended for Cursor):**
 

--- a/src/content/docs/ides/google-antigravity.md
+++ b/src/content/docs/ides/google-antigravity.md
@@ -25,7 +25,8 @@ Antigravity uses `.agent/skills/` at the project level. Share skills from your c
 **Copy-on-change (recommended):**
 
 ```bash
-cp -R .claude/skills .agent/skills
+mkdir -p .agent/skills
+cp -R .claude/skills/. .agent/skills/
 ```
 
 Automate with a Git hook or file watcher so copies stay in sync.
@@ -55,8 +56,8 @@ Share your canonical commands folder using copy-on-change or a symlink:
 **Copy-on-change (recommended):**
 
 ```bash
-mkdir -p .agent
-cp -R .claude/commands .agent/workflows
+mkdir -p .agent/workflows
+cp -R .claude/commands/. .agent/workflows/
 ```
 
 **Symlink (macOS/Linux only):**

--- a/src/content/docs/ides/google-antigravity.md
+++ b/src/content/docs/ides/google-antigravity.md
@@ -22,14 +22,16 @@ Antigravity uses progressive disclosure for skills — each skill sits dormant u
 
 Antigravity uses `.agent/skills/` at the project level. Share skills from your canonical location using copy-on-change or a symlink:
 
-**Copy-on-change (recommended):**
+**Rsync (recommended):**
 
 ```bash
+# Gather any local changes back to canonical, then mirror
+[ -d .agent/skills ] && rsync -a .agent/skills/ .claude/skills/
 mkdir -p .agent/skills
-cp -R .claude/skills/. .agent/skills/
+rsync -a --delete .claude/skills/ .agent/skills/
 ```
 
-Automate with a Git hook or file watcher so copies stay in sync.
+Automate with a Git hook or file watcher so copies stay in sync. See [Skills — Sync with rsync](/skills#strategy-1--sync-with-rsync-recommended-for-most-teams) for the full two-step pattern covering all IDEs.
 
 **Symlink (macOS/Linux only):**
 
@@ -53,11 +55,12 @@ For more about how skills work in factory engineering, see [Skills](/skills).
 
 Share your canonical commands folder using copy-on-change or a symlink:
 
-**Copy-on-change (recommended):**
+**Rsync (recommended):**
 
 ```bash
+[ -d .agent/workflows ] && rsync -a .agent/workflows/ .claude/commands/
 mkdir -p .agent/workflows
-cp -R .claude/commands/. .agent/workflows/
+rsync -a --delete .claude/commands/ .agent/workflows/
 ```
 
 **Symlink (macOS/Linux only):**

--- a/src/content/docs/ides/google-antigravity.md
+++ b/src/content/docs/ides/google-antigravity.md
@@ -20,11 +20,23 @@ Google Antigravity is an AI-native IDE powered by Gemini. It uses progressive di
 
 Antigravity uses progressive disclosure for skills — each skill sits dormant until a request matches its description, at which point it is loaded into the agent's context. **AgentKit 2.0** (March 2026) added multi-agent orchestration via Manager View but did not change skills loading: skills still live in `.agent/skills/` and are loaded on-demand by whichever specialized agent is handling the task.
 
-Antigravity uses `.agent/skills/` at the project level. A symlink to your canonical location is required:
+Antigravity uses `.agent/skills/` at the project level. Share skills from your canonical location using copy-on-change or a symlink:
+
+**Copy-on-change (recommended):**
+
+```bash
+cp -R .claude/skills .agent/skills
+```
+
+Automate with a Git hook or file watcher so copies stay in sync.
+
+**Symlink (macOS/Linux only):**
 
 ```bash
 ln -s ../.claude/skills .agent/skills
 ```
+
+Symlinks require macOS/Linux and may not work on Windows clones. See [Skills — Managing Skills Across IDEs](/skills#managing-skills-across-ides) for details on caveats and alternatives.
 
 📖 [Google Antigravity Skills Documentation](https://antigravity.google/docs/skills)
 
@@ -38,14 +50,23 @@ For more about how skills work in factory engineering, see [Skills](/skills).
 
 **Invocation:** `/workflow-name` — Antigravity treats files in `.agent/workflows/` as workflows. With the symlink, your `.claude/commands/` files appear there. Use **slash-command at-artifact** (e.g. `/write-spec @submit-sales-order`).
 
-Create the symlink:
+Share your canonical commands folder using copy-on-change or a symlink:
+
+**Copy-on-change (recommended):**
+
+```bash
+mkdir -p .agent
+cp -R .claude/commands .agent/workflows
+```
+
+**Symlink (macOS/Linux only):**
 
 ```bash
 mkdir -p .agent
 ln -s ../.claude/commands .agent/workflows
 ```
 
-Without the symlink, you would have to maintain a separate copy of commands in `.agent/workflows/`.
+Without sharing, you would have to maintain a separate copy of commands in `.agent/workflows/`.
 
 For more about how commands work in factory engineering, see [Commands](/commands).
 

--- a/src/content/docs/ides/google-antigravity.md
+++ b/src/content/docs/ides/google-antigravity.md
@@ -51,7 +51,7 @@ For more about how skills work in factory engineering, see [Skills](/skills).
 
 **Folder location:** `.agent/workflows/` (project)
 
-**Invocation:** `/workflow-name` — Antigravity treats files in `.agent/workflows/` as workflows. With the symlink, your `.claude/commands/` files appear there. Use **slash-command at-artifact** (e.g. `/write-spec @submit-sales-order`).
+**Invocation:** `/workflow-name` — Antigravity treats files in `.agent/workflows/` as workflows. With sharing (rsync or symlink), your `.claude/commands/` files appear there. Use **slash-command at-artifact** (e.g. `/write-spec @submit-sales-order`).
 
 Share your canonical commands folder using copy-on-change or a symlink:
 

--- a/src/content/docs/ides/kilo-code.md
+++ b/src/content/docs/ides/kilo-code.md
@@ -18,11 +18,23 @@ Kilo Code is an open-source VS Code extension with a model aggregator backend th
 | Project | `.kilocode/skills/` |
 | Global | `~/.kilocode/skills/` |
 
-Kilo Code loads skills from `.kilocode/skills/`. A symlink to your canonical location is required:
+Kilo Code loads skills from `.kilocode/skills/`. Share skills from your canonical location using copy-on-change or a symlink:
+
+**Copy-on-change (recommended):**
+
+```bash
+cp -R .claude/skills .kilocode/skills
+```
+
+Automate with a Git hook or file watcher so copies stay in sync.
+
+**Symlink (macOS/Linux only):**
 
 ```bash
 ln -s ../.claude/skills .kilocode/skills
 ```
+
+Symlinks require macOS/Linux and may not work on Windows clones. See [Skills — Managing Skills Across IDEs](/skills#managing-skills-across-ides) for details on caveats and alternatives.
 
 Kilo Code was one of the first agents to natively implement the Agent Skills specification with zero-configuration detection. Skills are evaluated before every response — the agent checks all skill descriptions against your request and loads the most relevant one.
 
@@ -48,7 +60,15 @@ Kilo Code calls them "workflows" — this is Kilo Code's storage mechanism for c
 /write-spec @submit-sales-order
 ```
 
-Use a symlink so `.kilocode/workflows` points to `.claude/commands`:
+Share your canonical commands folder using copy-on-change or a symlink:
+
+**Copy-on-change (recommended):**
+
+```bash
+cp -R .claude/commands .kilocode/workflows
+```
+
+**Symlink (macOS/Linux only):**
 
 ```bash
 ln -s ../.claude/commands .kilocode/workflows

--- a/src/content/docs/ides/kilo-code.md
+++ b/src/content/docs/ides/kilo-code.md
@@ -23,7 +23,8 @@ Kilo Code loads skills from `.kilocode/skills/`. Share skills from your canonica
 **Copy-on-change (recommended):**
 
 ```bash
-cp -R .claude/skills .kilocode/skills
+mkdir -p .kilocode/skills
+cp -R .claude/skills/. .kilocode/skills/
 ```
 
 Automate with a Git hook or file watcher so copies stay in sync.
@@ -65,7 +66,8 @@ Share your canonical commands folder using copy-on-change or a symlink:
 **Copy-on-change (recommended):**
 
 ```bash
-cp -R .claude/commands .kilocode/workflows
+mkdir -p .kilocode/workflows
+cp -R .claude/commands/. .kilocode/workflows/
 ```
 
 **Symlink (macOS/Linux only):**

--- a/src/content/docs/ides/kilo-code.md
+++ b/src/content/docs/ides/kilo-code.md
@@ -20,14 +20,16 @@ Kilo Code is an open-source VS Code extension with a model aggregator backend th
 
 Kilo Code loads skills from `.kilocode/skills/`. Share skills from your canonical location using copy-on-change or a symlink:
 
-**Copy-on-change (recommended):**
+**Rsync (recommended):**
 
 ```bash
+# Gather any local changes back to canonical, then mirror
+[ -d .kilocode/skills ] && rsync -a .kilocode/skills/ .claude/skills/
 mkdir -p .kilocode/skills
-cp -R .claude/skills/. .kilocode/skills/
+rsync -a --delete .claude/skills/ .kilocode/skills/
 ```
 
-Automate with a Git hook or file watcher so copies stay in sync.
+Automate with a Git hook or file watcher so copies stay in sync. See [Skills — Sync with rsync](/skills#strategy-1--sync-with-rsync-recommended-for-most-teams) for the full two-step pattern covering all IDEs.
 
 **Symlink (macOS/Linux only):**
 
@@ -63,11 +65,12 @@ Kilo Code calls them "workflows" — this is Kilo Code's storage mechanism for c
 
 Share your canonical commands folder using copy-on-change or a symlink:
 
-**Copy-on-change (recommended):**
+**Rsync (recommended):**
 
 ```bash
+[ -d .kilocode/workflows ] && rsync -a .kilocode/workflows/ .claude/commands/
 mkdir -p .kilocode/workflows
-cp -R .claude/commands/. .kilocode/workflows/
+rsync -a --delete .claude/commands/ .kilocode/workflows/
 ```
 
 **Symlink (macOS/Linux only):**

--- a/src/content/docs/ides/openai-codex.md
+++ b/src/content/docs/ides/openai-codex.md
@@ -19,14 +19,25 @@ OpenAI Codex adopted the Agent Skills open standard in December 2025, reaching p
 | User | `~/.agents/skills/` |
 | Admin | `/etc/codex/skills/` |
 
-Codex uses the shared `.agents/skills/` convention (not a Codex-specific folder) and evaluates each skill's `description` via progressive disclosure to decide when to load it. Symlinks to a canonical skills directory are supported.
+Codex uses the shared `.agents/skills/` convention (not a Codex-specific folder) and evaluates each skill's `description` via progressive disclosure to decide when to load it. Share skills from your canonical location using copy-on-change or a symlink:
 
-Create the symlink to your canonical location:
+**Copy-on-change (recommended):**
+
+```bash
+mkdir -p .agents
+cp -R .claude/skills .agents/skills
+```
+
+Automate with a Git hook or file watcher so copies stay in sync.
+
+**Symlink (macOS/Linux only):**
 
 ```bash
 mkdir -p .agents
 ln -s ../.claude/skills .agents/skills
 ```
+
+Symlinks require macOS/Linux and may not work on Windows clones. See [Skills — Managing Skills Across IDEs](/skills#managing-skills-across-ides) for details on caveats and alternatives.
 
 Codex supports the standard `user-invocable` and `disable-model-invocation` frontmatter properties for controlling when a skill is loaded automatically versus invoked by name. Inside Codex, list loaded skills with the `/skills` command and invoke a skill explicitly by name with `$skill-name`.
 

--- a/src/content/docs/ides/openai-codex.md
+++ b/src/content/docs/ides/openai-codex.md
@@ -24,8 +24,8 @@ Codex uses the shared `.agents/skills/` convention (not a Codex-specific folder)
 **Copy-on-change (recommended):**
 
 ```bash
-mkdir -p .agents
-cp -R .claude/skills .agents/skills
+mkdir -p .agents/skills
+cp -R .claude/skills/. .agents/skills/
 ```
 
 Automate with a Git hook or file watcher so copies stay in sync.

--- a/src/content/docs/ides/openai-codex.md
+++ b/src/content/docs/ides/openai-codex.md
@@ -21,14 +21,16 @@ OpenAI Codex adopted the Agent Skills open standard in December 2025, reaching p
 
 Codex uses the shared `.agents/skills/` convention (not a Codex-specific folder) and evaluates each skill's `description` via progressive disclosure to decide when to load it. Share skills from your canonical location using copy-on-change or a symlink:
 
-**Copy-on-change (recommended):**
+**Rsync (recommended):**
 
 ```bash
+# Gather any local changes back to canonical, then mirror
+[ -d .agents/skills ] && rsync -a .agents/skills/ .claude/skills/
 mkdir -p .agents/skills
-cp -R .claude/skills/. .agents/skills/
+rsync -a --delete .claude/skills/ .agents/skills/
 ```
 
-Automate with a Git hook or file watcher so copies stay in sync.
+Automate with a Git hook or file watcher so copies stay in sync. See [Skills — Sync with rsync](/skills#strategy-1--sync-with-rsync-recommended-for-most-teams) for the full two-step pattern covering all IDEs.
 
 **Symlink (macOS/Linux only):**
 

--- a/src/content/docs/ides/windsurf.md
+++ b/src/content/docs/ides/windsurf.md
@@ -23,7 +23,8 @@ Windsurf's Cascade agent looks for skills in `.windsurf/skills/`. Share skills f
 **Copy-on-change (recommended):**
 
 ```bash
-cp -R .claude/skills .windsurf/skills
+mkdir -p .windsurf/skills
+cp -R .claude/skills/. .windsurf/skills/
 ```
 
 Automate with a Git hook or file watcher so copies stay in sync.
@@ -63,7 +64,8 @@ Share your canonical commands folder using copy-on-change or a symlink:
 **Copy-on-change (recommended):**
 
 ```bash
-cp -R .claude/commands .windsurf/workflows
+mkdir -p .windsurf/workflows
+cp -R .claude/commands/. .windsurf/workflows/
 ```
 
 **Symlink (macOS/Linux only):**

--- a/src/content/docs/ides/windsurf.md
+++ b/src/content/docs/ides/windsurf.md
@@ -18,11 +18,23 @@ Windsurf is an AI-powered code editor featuring Cascade, a single shared AI agen
 | Project | `.windsurf/skills/` |
 | Global | `~/.windsurf/skills/` |
 
-Windsurf's Cascade agent looks for skills in `.windsurf/skills/`. A symlink to your canonical location is required:
+Windsurf's Cascade agent looks for skills in `.windsurf/skills/`. Share skills from your canonical location using copy-on-change or a symlink:
+
+**Copy-on-change (recommended):**
+
+```bash
+cp -R .claude/skills .windsurf/skills
+```
+
+Automate with a Git hook or file watcher so copies stay in sync.
+
+**Symlink (macOS/Linux only):**
 
 ```bash
 ln -s ../.claude/skills .windsurf/skills
 ```
+
+Symlinks require macOS/Linux and may not work on Windows clones. See [Skills — Managing Skills Across IDEs](/skills#managing-skills-across-ides) for details on caveats and alternatives.
 
 Cascade automatically invokes skills when your request matches a skill's description. To invoke a skill explicitly, type `@skill-name` in the Cascade input.
 
@@ -46,7 +58,15 @@ Windsurf calls them "workflows" — note that this is different from workflows i
 /write-spec @submit-sales-order
 ```
 
-Create a symlink to use your canonical commands folder:
+Share your canonical commands folder using copy-on-change or a symlink:
+
+**Copy-on-change (recommended):**
+
+```bash
+cp -R .claude/commands .windsurf/workflows
+```
+
+**Symlink (macOS/Linux only):**
 
 ```bash
 ln -s ../.claude/commands .windsurf/workflows

--- a/src/content/docs/ides/windsurf.md
+++ b/src/content/docs/ides/windsurf.md
@@ -20,14 +20,16 @@ Windsurf is an AI-powered code editor featuring Cascade, a single shared AI agen
 
 Windsurf's Cascade agent looks for skills in `.windsurf/skills/`. Share skills from your canonical location using copy-on-change or a symlink:
 
-**Copy-on-change (recommended):**
+**Rsync (recommended):**
 
 ```bash
+# Gather any local changes back to canonical, then mirror
+[ -d .windsurf/skills ] && rsync -a .windsurf/skills/ .claude/skills/
 mkdir -p .windsurf/skills
-cp -R .claude/skills/. .windsurf/skills/
+rsync -a --delete .claude/skills/ .windsurf/skills/
 ```
 
-Automate with a Git hook or file watcher so copies stay in sync.
+Automate with a Git hook or file watcher so copies stay in sync. See [Skills — Sync with rsync](/skills#strategy-1--sync-with-rsync-recommended-for-most-teams) for the full two-step pattern covering all IDEs.
 
 **Symlink (macOS/Linux only):**
 
@@ -61,11 +63,12 @@ Windsurf calls them "workflows" — note that this is different from workflows i
 
 Share your canonical commands folder using copy-on-change or a symlink:
 
-**Copy-on-change (recommended):**
+**Rsync (recommended):**
 
 ```bash
+[ -d .windsurf/workflows ] && rsync -a .windsurf/workflows/ .claude/commands/
 mkdir -p .windsurf/workflows
-cp -R .claude/commands/. .windsurf/workflows/
+rsync -a --delete .claude/commands/ .windsurf/workflows/
 ```
 
 **Symlink (macOS/Linux only):**

--- a/src/content/docs/skills.md
+++ b/src/content/docs/skills.md
@@ -120,8 +120,8 @@ Keep canonical skills in `.claude/skills/` and use a watcher, Git hook, or CI st
 ```bash
 # Example: copy skills into each IDE folder after a change
 for dest in .windsurf/skills .kilocode/skills .agent/skills .agents/skills; do
-  mkdir -p "$(dirname "$dest")"
-  cp -R .claude/skills "$dest"
+  mkdir -p "$dest"
+  cp -R .claude/skills/. "$dest"/
 done
 ```
 

--- a/src/content/docs/skills.md
+++ b/src/content/docs/skills.md
@@ -101,13 +101,11 @@ From here, every team member can invoke the skill by describing the task or by n
 
 ---
 
-## Managing Skills Across IDEs: The Symlink Approach
+## Managing Skills Across IDEs
 
-Different IDEs look for skills in different folders. Managing multiple copies of the same skill across multiple folders is not viable for a team—it creates drift, duplication, and maintenance burden.
+Different IDEs look for skills in different folders. Managing multiple copies of the same skill across multiple folders is not viable for a team—it creates drift, duplication, and maintenance burden. Establish one canonical skills location in your repository and use one of the strategies below to keep every IDE in sync.
 
-Establish one canonical skills location in your repository and use symlinks to point each IDE's expected folder to that location.
-
-**Canonical location (recommended):**
+**Canonical location:**
 
 ```
 .claude/skills/
@@ -115,7 +113,36 @@ Establish one canonical skills location in your repository and use symlinks to p
 
 This folder is the most widely recognized across the ecosystem. Use it as your source of truth.
 
-**Option A — Use the factory-engineering skill:** Install with `npx openskills install factoryengineering/skills`, then ask your agent to create symlinks. The skill sets up symlinks for **commands/workflows** (`.claude/commands/`) and, for IDEs that need them, **skills** (`.claude/skills/` → Windsurf, Kilo Code, Antigravity, OpenAI Codex; Cursor and Copilot read `.claude/skills/` directly). Use `--type all` (default) for both, or `--type commands` / `--type skills`. The agent can detect which IDEs you have, confirm with you, and offer to copy existing contents into the canonical folder if a target already exists. On Windows, use the skill's PowerShell script. See the [Commands](/commands) page for the full symlink approach and the skill’s SKILL.md (and symlinks.md) for script options.
+### Strategy 1 — Copy-on-Change (recommended for most teams)
+
+Keep canonical skills in `.claude/skills/` and use a watcher, Git hook, or CI step to copy them into each IDE’s expected folder when they change. This approach works on every OS, avoids symlink pitfalls, and produces real files that every IDE’s file watcher can detect reliably.
+
+```bash
+# Example: copy skills into each IDE folder after a change
+for dest in .windsurf/skills .kilocode/skills .agent/skills .agents/skills; do
+  mkdir -p "$(dirname "$dest")"
+  cp -R .claude/skills "$dest"
+done
+```
+
+Automate this with a `post-commit` or `post-merge` Git hook, a file-watcher script, or a CI step so copies never drift. Commit the copied folders so every team member gets them on clone.
+
+### Strategy 2 — IDE-Native Locations Only
+
+Store skills directly in each IDE’s folder (`.windsurf/skills/`, `.kilocode/skills/`, etc.) and skip the canonical location for IDEs that do not read `.claude/skills/`. This is the simplest option for teams that use only one or two IDEs, but it increases maintenance burden as the number of IDEs grows.
+
+### Strategy 3 — Symlinks (macOS/Linux only, with caveats)
+
+Symlinks point each IDE’s expected folder to `.claude/skills/`. This avoids file duplication but comes with significant caveats:
+
+- **Windows:** Symlinks require Developer Mode or administrator privileges. Developer Mode is often restricted in corporate environments, and `core.symlinks` must be enabled in Git. Symlinks created on macOS/Linux may not resolve correctly when cloned on Windows even with Developer Mode enabled.
+- **Cursor:** Cursor’s file watcher does not properly follow directory symlinks. If you use Cursor, prefer copy-on-change or place skills directly in `.cursor/skills/` (Cursor also reads `.claude/skills/` directly, so a symlink is unnecessary for skills).
+- **IDE inconsistencies:** Some IDEs watch the symlink target correctly; others watch the symlink itself or skip watching entirely. Test with your specific IDE versions.
+- **Cross-platform Git:** Symlinks committed on macOS/Linux may appear as plain text files containing the target path when cloned on Windows, depending on the user’s Git configuration.
+
+If your team is macOS/Linux-only and does not use Cursor, symlinks remain a viable option:
+
+**Option A — Use the factory-engineering skill:** Install with `npx openskills install factoryengineering/skills`, then ask your agent to create symlinks. The skill sets up symlinks for **commands/workflows** (`.claude/commands/`) and, for IDEs that need them, **skills** (`.claude/skills/` → Windsurf, Kilo Code, Antigravity, OpenAI Codex; Cursor and Copilot read `.claude/skills/` directly). Use `--type all` (default) for both, or `--type commands` / `--type skills`. The agent can detect which IDEs you have, confirm with you, and offer to copy existing contents into the canonical folder if a target already exists. On Windows, use the skill’s PowerShell script. See the [Commands](/commands) page for more details and the skill’s SKILL.md (and symlinks.md) for script options.
 
 **Option B — Create symlinks manually for each IDE:**
 
@@ -135,23 +162,23 @@ ln -s ../.claude/skills .agents/skills
 # Cursor and GitHub Copilot read .claude/skills directly — no symlink needed
 ```
 
-Commit the symlinks to your repository. Every team member gets the correct folder structure automatically on clone, regardless of which IDE they use.
+Commit the symlinks to your repository. Every team member on macOS/Linux gets the correct folder structure automatically on clone.
 
 ---
 
 ## IDE-by-IDE Reference
 
-Every major AI IDE supports the Agent Skills standard. The table below summarizes folder locations and symlink requirements. For full setup details, see each IDE's dedicated page.
+Every major AI IDE supports the Agent Skills standard. The table below summarizes folder locations and sharing requirements. Use copy-on-change, IDE-native locations, or symlinks (see [Managing Skills Across IDEs](#managing-skills-across-ides)) depending on your team's OS and IDE mix.
 
-| IDE | Project Folder | Symlink Needed? | Details |
-|-----|---------------|-----------------|---------|
+| IDE | Project Folder | Sharing Required? | Details |
+|-----|---------------|-------------------|---------|
 | [Claude Code](/ides/claude-code) | `.claude/skills/` | No (canonical location) | [Full setup →](/ides/claude-code#skills) |
 | [GitHub Copilot](/ides/github-copilot) | `.github/skills/` + `.claude/skills/` | No (reads `.claude/skills/` directly) | [Full setup →](/ides/github-copilot#skills) |
 | [Cursor](/ides/cursor) | `.cursor/skills/` + `.claude/skills/` | No (reads `.claude/skills/` directly) | [Full setup →](/ides/cursor#skills) |
-| [Windsurf](/ides/windsurf) | `.windsurf/skills/` | ✅ Yes | [Full setup →](/ides/windsurf#skills) |
-| [Kilo Code](/ides/kilo-code) | `.kilocode/skills/` | ✅ Yes | [Full setup →](/ides/kilo-code#skills) |
-| [Google Antigravity](/ides/google-antigravity) | `.agent/skills/` | ✅ Yes | [Full setup →](/ides/google-antigravity#skills) |
-| [OpenAI Codex](/ides/openai-codex) | `.agents/skills/` | ✅ Yes | [Full setup →](/ides/openai-codex#skills) |
+| [Windsurf](/ides/windsurf) | `.windsurf/skills/` | ✅ Yes (copy or symlink) | [Full setup →](/ides/windsurf#skills) |
+| [Kilo Code](/ides/kilo-code) | `.kilocode/skills/` | ✅ Yes (copy or symlink) | [Full setup →](/ides/kilo-code#skills) |
+| [Google Antigravity](/ides/google-antigravity) | `.agent/skills/` | ✅ Yes (copy or symlink) | [Full setup →](/ides/google-antigravity#skills) |
+| [OpenAI Codex](/ides/openai-codex) | `.agents/skills/` | ✅ Yes (copy or symlink) | [Full setup →](/ides/openai-codex#skills) |
 
 ---
 
@@ -175,23 +202,7 @@ mkdir -p .claude/skills
 
 **2. Create your first skill:** Use the **skill-creator** skill (see [Installing skill-creator and skill-optimizer](#installing-skill-creator-and-skill-optimizer)). Ask your agent to create a new skill in `.claude/skills`; it will guide you through the workflow and produce a proper SKILL.md and directory structure.
 
-**3. Create symlinks for each IDE your team uses:** Use the **factory-engineering** skill (Option A above) and ask your agent to set up symlinks—it will create command symlinks and skill symlinks for IDEs that need them (Windsurf, Kilo Code, Antigravity, OpenAI Codex). Or create them manually:
-
-```bash
-# Windsurf
-ln -s ../.claude/skills .windsurf/skills
-
-# Kilo Code
-ln -s ../.claude/skills .kilocode/skills
-
-# Antigravity
-ln -s ../.claude/skills .agent/skills
-
-# OpenAI Codex
-ln -s ../.claude/skills .agents/skills
-
-# Cursor and GitHub Copilot read .claude/skills directly — no symlink needed
-```
+**3. Share skills with each IDE your team uses:** Choose the strategy that fits your team (see [Managing Skills Across IDEs](#managing-skills-across-ides)). For most teams, **copy-on-change** is the safest default — it works on every OS and avoids symlink pitfalls. If your team is macOS/Linux-only and does not use Cursor, symlinks are also viable. You can use the **factory-engineering** skill to automate either approach, or set up sharing manually.
 
 **4. Commit everything:**
 

--- a/src/content/docs/skills.md
+++ b/src/content/docs/skills.md
@@ -113,19 +113,33 @@ Different IDEs look for skills in different folders. Managing multiple copies of
 
 This folder is the most widely recognized across the ecosystem. Use it as your source of truth.
 
-### Strategy 1 — Copy-on-Change (recommended for most teams)
+### Strategy 1 — Sync with rsync (recommended for most teams)
 
-Keep canonical skills in `.claude/skills/` and use a watcher, Git hook, or CI step to copy them into each IDE’s expected folder when they change. This approach works on every OS, avoids symlink pitfalls, and produces real files that every IDE’s file watcher can detect reliably.
+Keep canonical skills in `.claude/skills/` and use a two-step `rsync` to keep every IDE folder in sync. This approach works on every OS (rsync is pre-installed on macOS and Linux, and available on Windows via Git Bash/MSYS2), avoids symlink pitfalls, and produces real files that every IDE’s file watcher can detect reliably.
+
+The two-step pattern handles the case where a developer edits a skill in a non-canonical location (e.g., `.kilocode/skills/`) rather than in `.claude/skills/`. Step 1 gathers those changes back to canonical before step 2 mirrors canonical everywhere, so no work is lost.
 
 ```bash
-# Example: copy skills into each IDE folder after a change
-for dest in .windsurf/skills .kilocode/skills .agent/skills .agents/skills; do
+#!/usr/bin/env bash
+# sync-skills.sh — run from repo root
+
+IDE_SKILLS=(.windsurf/skills .kilocode/skills .agent/skills .agents/skills)
+
+# Step 1: reverse-sync — gather changes from any IDE location back to canonical
+for src in "${IDE_SKILLS[@]}"; do
+  [ -d "$src" ] && rsync -a "$src/" .claude/skills/
+done
+
+# Step 2: forward-sync — mirror canonical to all IDE locations
+for dest in "${IDE_SKILLS[@]}"; do
   mkdir -p "$dest"
-  cp -R .claude/skills/. "$dest"/
+  rsync -a --delete .claude/skills/ "$dest"/
 done
 ```
 
-Automate this with a `post-commit` or `post-merge` Git hook, a file-watcher script, or a CI step so copies never drift. Commit the copied folders so every team member gets them on clone.
+**Step 1** is additive (no `--delete`): new or modified files in any IDE folder are copied back to `.claude/skills/` without removing anything. **Step 2** uses `--delete` so each destination becomes an exact mirror of canonical — stale files that were removed from `.claude/skills/` are cleaned up.
+
+Automate this with a `post-commit` or `post-merge` Git hook, a file-watcher script, or a CI step so copies never drift. Commit the synced folders so every team member gets them on clone.
 
 ### Strategy 2 — IDE-Native Locations Only
 

--- a/src/content/docs/skills.md
+++ b/src/content/docs/skills.md
@@ -125,6 +125,9 @@ The two-step pattern handles the case where a developer edits a skill in a non-c
 
 IDE_SKILLS=(.windsurf/skills .kilocode/skills .agent/skills .agents/skills)
 
+# Ensure canonical directory exists (first-time setup)
+mkdir -p .claude/skills
+
 # Step 1: reverse-sync — gather changes from any IDE location back to canonical
 for src in "${IDE_SKILLS[@]}"; do
   [ -d "$src" ] && rsync -a "$src/" .claude/skills/

--- a/src/content/docs/workflows.md
+++ b/src/content/docs/workflows.md
@@ -13,7 +13,7 @@ This is the highest layer of the software factory. Skills encode knowledge. Comm
 
 Several IDEs use the word "workflow" for something else. Windsurf and Kilo Code both have features they call "Workflows." Those are reusable slash commands, not orchestration of named agents. This page uses the factory engineering meaning: orchestration of agents, with delegation, branching, and looping.
 
-**Invocation:** Use **slash-workflow at-artifact**, e.g. `/tdd-cycle @docs/specs/order-validation.md`. The workflow name is the filename without `.md`. Store workflows in `.claude/commands/` so they sit alongside commands and can be invoked the same way. Symlinks from `.cursor/commands/`, `.windsurf/workflows/`, `.kilocode/workflows/`, and `.agent/workflows/` point to `.claude/commands/` so every IDE sees the same files (see the [Commands](/commands) page).
+**Invocation:** Use **slash-workflow at-artifact**, e.g. `/tdd-cycle @docs/specs/order-validation.md`. The workflow name is the filename without `.md`. Store workflows in `.claude/commands/` so they sit alongside commands and can be invoked the same way. Share them into `.cursor/commands/`, `.windsurf/workflows/`, `.kilocode/workflows/`, and `.agent/workflows/` via copy-on-change or symlinks so every IDE sees the same files (see the [Commands](/commands) page).
 
 ---
 
@@ -23,11 +23,11 @@ Store workflow documents in `.claude/commands/`. That gives you:
 
 - **One place for both commands and workflows.** The user invokes a workflow by name; the file lives next to single-agent commands.
 - **Slash-workflow at-artifact.** Invoke with `/workflow-name @path/to/artifact`. The workflow name is the filename without `.md`; the artifact is the input (e.g. a spec, a design, a user story).
-- **Shared across IDEs.** Symlink `.claude/commands/` into each IDE’s commands/workflows folder so the same workflow file is available everywhere.
+- **Shared across IDEs.** Share `.claude/commands/` into each IDE’s commands/workflows folder (via copy-on-change or symlinks) so the same workflow file is available everywhere.
 
-Do not maintain separate copies of the same workflow in each IDE. Use symlinks. Without the symlink, you would have to keep each copy in sync by hand.
+Do not maintain separate copies of the same workflow in each IDE by hand. Use copy-on-change (recommended) or symlinks to keep them in sync automatically. See the [Commands](/commands#sharing-commands-across-ides) page for strategy details.
 
-Because workflows are stored in `.claude/commands/` and shared via symlinks (like commands), keep them **IDE-agnostic**: do not rely on `$ARGUMENTS` or other placeholders. Not all IDEs support them. State in the workflow what the user will supply (e.g. a design or specification, via slash-workflow at-artifact) and instruct the orchestrator to stop and prompt the user if that input is missing. See the [Commands](/commands) page for the same pattern.
+Because workflows are stored in `.claude/commands/` and shared across IDEs (like commands), keep them **IDE-agnostic**: do not rely on `$ARGUMENTS` or other placeholders. Not all IDEs support them. State in the workflow what the user will supply (e.g. a design or specification, via slash-workflow at-artifact) and instruct the orchestrator to stop and prompt the user if that input is missing. See the [Commands](/commands) page for the same pattern.
 
 ---
 


### PR DESCRIPTION
Reframe symlinks from the recommended approach to one of three strategies
for sharing skills and commands across IDEs. Introduces copy-on-change as
the recommended default, IDE-native locations as a simple alternative, and
symlinks as a macOS/Linux-only option with documented caveats (Windows
Developer Mode, Cursor file-watcher bug, cross-platform Git issues, IDE
inconsistencies).

Updates 9 documentation pages: skills.md, commands.md, workflows.md,
ides.md, and IDE-specific pages for Cursor, Windsurf, Kilo Code, Google
Antigravity, and OpenAI Codex.

Fixes #25, fixes #26

https://claude.ai/code/session_01A3k2QYBKaW1k1pgQYquLs2