### PR TITLE
Halve chat animation height for recording and rendering

### DIFF
--- a/.claude/skills/add-article/SKILL.md
+++ b/.claude/skills/add-article/SKILL.md
@@ -58,7 +58,14 @@ import ChatAnim from '~/components/user-components/ChatAnim.astro';
 <ChatAnim src="/animations/NN-title-in-kebab-case.gif" alt="Description of the exchange" />
 ```
 
-Keep the animation to the essential beats: the initial prompt, one or two corrections, and the payoff. Do not reproduce every code block from the article. Target 15 seconds or less.
+Keep the animation to the essential beats: the initial prompt, one or two corrections, and the payoff. Do not reproduce every code block from the article. Target 15 seconds or less — note that `pause_on_last_ms` defaults to 4000, so budget about 11 seconds for the typing itself.
+
+The default viewport height (`config.height`) is 210 px, which only fits about two short bubbles before older content scrolls out. Multi-exchange animations should override it in the YAML — article 03 and 04 use `height: 340`, for example:
+
+```yaml
+config:
+  height: 340
+```
 
 ## 5. References footer
 

--- a/.claude/skills/chat-anim-renderer/assets/defaults.js
+++ b/.claude/skills/chat-anim-renderer/assets/defaults.js
@@ -5,7 +5,7 @@
 module.exports = {
   // Canvas
   width:              360,
-  height:             420,
+  height:             210,
   fps:                15,
 
   // Timing (milliseconds)

--- a/.claude/skills/chat-anim-renderer/assets/defaults.js
+++ b/.claude/skills/chat-anim-renderer/assets/defaults.js
@@ -12,7 +12,7 @@ module.exports = {
   char_delay_user_ms: 28,
   char_delay_ai_ms:   18,
   think_delay_ms:     900,
-  pause_on_last_ms:   2000,
+  pause_on_last_ms:   4000,
 
   // Theme
   theme:              'dark',

--- a/.claude/skills/chat-anim-renderer/references/encoding.md
+++ b/.claude/skills/chat-anim-renderer/references/encoding.md
@@ -47,7 +47,7 @@ YAML file. Requires gifski to be installed (`cargo install gifski` or
 
 ## File size targets
 
-For web embedding at 720×420:
+For web embedding at the default 360×210 canvas:
 
 | Duration | FFmpeg (default) | gifski q=90 |
 |---|---|---|

--- a/.claude/skills/chat-anim-renderer/references/troubleshooting.md
+++ b/.claude/skills/chat-anim-renderer/references/troubleshooting.md
@@ -55,7 +55,7 @@ Cause: the extra-frames calculation rounded to zero, or
 `pause_on_last_ms` was not merged from defaults.
 
 Fix: confirm `config.pause_on_last_ms` is > 0 in the merged config. At `fps=15`
-and `pause_on_last_ms=2000`, expect 30 trailing identical frames.
+and `pause_on_last_ms=4000`, expect 60 trailing identical frames.
 
 ## Output is placed in the wrong directory
 

--- a/.claude/skills/chat-anim-renderer/references/yaml-schema.md
+++ b/.claude/skills/chat-anim-renderer/references/yaml-schema.md
@@ -7,7 +7,7 @@ Source of truth for the conversation input format.
 ```yaml
 config:        # optional — any key overrides defaults.js
   width: 720
-  height: 420
+  height: 210
   fps: 15
   char_delay_user_ms: 28
   char_delay_ai_ms: 18

--- a/.claude/skills/chat-anim-renderer/references/yaml-schema.md
+++ b/.claude/skills/chat-anim-renderer/references/yaml-schema.md
@@ -6,13 +6,13 @@ Source of truth for the conversation input format.
 
 ```yaml
 config:        # optional — any key overrides defaults.js
-  width: 720
+  width: 360
   height: 210
   fps: 15
   char_delay_user_ms: 28
   char_delay_ai_ms: 18
   think_delay_ms: 900
-  pause_on_last_ms: 2000
+  pause_on_last_ms: 4000
   encoder: ffmpeg    # or 'gifski'
 
 exchanges:     # required, non-empty

--- a/chat-anims/example.chat.yaml
+++ b/chat-anims/example.chat.yaml
@@ -1,6 +1,6 @@
 config:
   width: 360
-  height: 420
+  height: 210
 
 exchanges:
   - role: user

--- a/docs/design/chat-animation-pipeline-spec.md
+++ b/docs/design/chat-animation-pipeline-spec.md
@@ -46,7 +46,7 @@ The `config` section is optional. All visual and timing parameters have defaults
 # Optional — override any default
 config:
   width: 720
-  height: 420
+  height: 210
   fps: 15
   theme: dark
   char_delay_user_ms: 28
@@ -90,7 +90,7 @@ All defaults are derived from the factoryengineering.dev visual identity. Develo
 module.exports = {
   // Canvas
   width:              360,
-  height:             420,
+  height:             210,
   fps:                15,
 
   // Timing (milliseconds)

--- a/docs/design/chat-animation-pipeline-spec.md
+++ b/docs/design/chat-animation-pipeline-spec.md
@@ -45,14 +45,14 @@ The `config` section is optional. All visual and timing parameters have defaults
 ```yaml
 # Optional — override any default
 config:
-  width: 720
+  width: 360
   height: 210
   fps: 15
   theme: dark
   char_delay_user_ms: 28
   char_delay_ai_ms: 18
   think_delay_ms: 900
-  pause_on_last_ms: 2000
+  pause_on_last_ms: 4000
   font_mono: "JetBrainsMono-Regular.ttf"
 
 exchanges:
@@ -97,7 +97,7 @@ module.exports = {
   char_delay_user_ms: 28,
   char_delay_ai_ms:   18,
   think_delay_ms:     900,
-  pause_on_last_ms:   2000,   // hold on final frame before loop
+  pause_on_last_ms:   4000,   // hold on final frame before loop
 
   // Theme — dark, matching factoryengineering.dev
   theme:              'dark',

--- a/src/content/docs/articles/03-do-the-work-then-capture-it.chat.yaml
+++ b/src/content/docs/articles/03-do-the-work-then-capture-it.chat.yaml
@@ -1,5 +1,5 @@
 config:
-  height: 680
+  height: 340
 
 exchanges:
   - role: user

--- a/src/content/docs/articles/04-test-your-skill-in-a-clean-room.chat.yaml
+++ b/src/content/docs/articles/04-test-your-skill-in-a-clean-room.chat.yaml
@@ -1,5 +1,5 @@
 config:
-  height: 680
+  height: 340
 
 exchanges:
   - role: user

--- a/tools/chat-anim/defaults.js
+++ b/tools/chat-anim/defaults.js
@@ -5,7 +5,7 @@
 module.exports = {
   // Canvas
   width:              360,
-  height:             420,
+  height:             210,
   fps:                15,
 
   // Timing (milliseconds)

--- a/tools/chat-anim/defaults.js
+++ b/tools/chat-anim/defaults.js
@@ -12,7 +12,7 @@ module.exports = {
   char_delay_user_ms: 28,
   char_delay_ai_ms:   18,
   think_delay_ms:     900,
-  pause_on_last_ms:   2000,
+  pause_on_last_ms:   4000,
 
   // Theme
   theme:              'dark',


### PR DESCRIPTION
Cuts the canvas height in half across the chat-anim pipeline so the
rendered GIFs take up less vertical space in article embeds. Updates
the pipeline defaults (210 was 420), the documented schema and spec,
the example YAML, and the two article chat animations (340 was 680).