### PR TITLE
Add getting started documentation for software factories

### DIFF
--- a/src/config/sidebar.json
+++ b/src/config/sidebar.json
@@ -1,6 +1,14 @@
 {
   "main": [
     {
+      "label": "Getting started",
+      "items": [
+        {"label": "What is a Software Factory?", "slug": "getting-started/introduction/overview"},
+        {"label": "Your First Skill in 5 Minutes", "slug": "getting-started/quick-start"},
+        {"label": "Where to Go Next", "slug": "getting-started/next-steps"}
+      ]
+    },
+    {
       "label": "Factory components",
       "items": [
         {"label": "Skills", "slug": "skills"},

--- a/src/content/docs/getting-started/introduction/overview.md
+++ b/src/content/docs/getting-started/introduction/overview.md
@@ -1,0 +1,60 @@
+---
+title: What is a Software Factory?
+description: A short introduction to factory engineering — what skills, commands, agents, and workflows are, and why teams compose them into repeatable processes.
+---
+
+# What is a Software Factory?
+
+Modern AI IDEs ship with a handful of features — **skills**, **commands**, **agents**, and **workflows** — that let you encode how *your* team writes software. A **software factory** is what you get when you compose those features into repeatable processes a whole team can rely on.
+
+Instead of every developer prompting the assistant from scratch, the factory captures your team's standards once and applies them everywhere: in code reviews, in PR descriptions, in test generation, in release notes. The assistant follows the factory; the factory evolves with the codebase.
+
+---
+
+## Why factory engineering matters
+
+Ad-hoc prompting is fast for one developer on one task. It does not scale to a team.
+
+- **Consistency.** Two developers asking the same question get the same answer, because the assistant loads the same skills and follows the same commands.
+- **Quality.** Standards live in version control alongside the code they govern, reviewed in pull requests like anything else.
+- **Shared knowledge.** A senior engineer's taste, encoded as a skill, becomes available to every teammate from their next session onward.
+- **Portability.** The same factory works across whichever AI IDE a teammate prefers — Claude Code, Cursor, Copilot, Windsurf, Kilo Code, Antigravity, or Codex.
+
+Factory engineering is the practice of building, testing, and refining these factories so that AI-assisted development produces reliable results, not lucky ones.
+
+---
+
+## The four factory components
+
+Every factory is built from four kinds of components. Each addresses a different need:
+
+- **[Skills](/skills)** — reusable capabilities that teach the assistant *how* to do a task. Skills carry knowledge, opinions, and supporting scripts. The assistant loads them automatically when relevant.
+- **[Commands](/commands)** — single-purpose, user-invoked instructions for specific tasks (`/review`, `/release-notes`). Composable and easy to share.
+- **[Agents](/agents)** — roles with memory that handle complex, multi-step construction and decision-making.
+- **[Workflows](/workflows)** — multi-step processes that coordinate multiple agents to accomplish sophisticated orchestrations.
+
+Most teams start with skills. A handful of well-tested skills will already raise the floor on quality across the team.
+
+---
+
+## Choose your IDE
+
+Factory components live in your repository, so they work across IDEs. Pick the guide that matches the tool your team uses today:
+
+- [Claude Code](/ides/claude-code)
+- [GitHub Copilot](/ides/github-copilot)
+- [Cursor](/ides/cursor)
+- [Windsurf](/ides/windsurf)
+- [Kilo Code](/ides/kilo-code)
+- [Google Antigravity](/ides/google-antigravity)
+- [OpenAI Codex](/ides/openai-codex)
+
+See the full comparison on the [IDEs](/ides) page.
+
+---
+
+## Ready to build something?
+
+The fastest way to understand factory engineering is to build a skill yourself. The next page walks through it in five minutes — no installs, no setup, just your existing AI IDE and a task you already do often.
+
+Continue to [Your First Skill in 5 Minutes →](/getting-started/quick-start/)

--- a/src/content/docs/getting-started/introduction/overview.md
+++ b/src/content/docs/getting-started/introduction/overview.md
@@ -57,4 +57,4 @@ See the full comparison on the [IDEs](/ides) page.
 
 The fastest way to understand factory engineering is to build a skill yourself. The next page walks through it in five minutes — no installs, no setup, just your existing AI IDE and a task you already do often.
 
-Continue to [Your First Skill in 5 Minutes →](/getting-started/quick-start/)
+Continue to [Your First Skill in 5 Minutes →](/getting-started/quick-start)

--- a/src/content/docs/getting-started/next-steps.md
+++ b/src/content/docs/getting-started/next-steps.md
@@ -1,0 +1,62 @@
+---
+title: Where to Go Next
+description: Recommended next steps after building your first skill — articles to deepen the practice, IDE-specific guides, and example factories to learn from.
+---
+
+# Where to Go Next
+
+You built a skill. Here is the path most teams follow from there.
+
+---
+
+## Read the article series
+
+The Build Your Software Factory articles go deeper into the practices you just touched on. They are short, hands-on, and build on each other.
+
+- [Article 1 — Do the Work, Then Capture It](/articles/03-do-the-work-then-capture-it/) — The full version of the loop you just ran, with worked corrections.
+- [Article 2 — Test Your Skill in a Clean Room](/articles/04-test-your-skill-in-a-clean-room/) — How to verify a skill works without leaning on context the assistant should not have.
+- [Article 3 — The Retrospective: "Did You Use a Skill?"](/articles/05-the-retrospective-did-you-use-a-skill/) — The single team habit that turns one-off prompts into durable factory components.
+- [Article 4 — Sharpen Your Skill with /skill-optimizer](/articles/06-sharpen-your-skill-with-skill-optimizer/) — Apply authoring best practices to a skill you already have.
+- [Article 5 — A Skill That Holds Up Under Pressure](/articles/07-a-skill-that-holds-up-under-pressure/) — What it looks like when a skill graduates from "works on my machine" to a team standard.
+
+Browse the full list on the [Articles](/articles) page.
+
+---
+
+## Set up your IDE
+
+Each AI IDE has its own folder conventions and sharing requirements. The IDE guides cover everything you need — skills, commands, agents, workflows — for the tool you actually use.
+
+- [Claude Code](/ides/claude-code)
+- [GitHub Copilot](/ides/github-copilot)
+- [Cursor](/ides/cursor)
+- [Windsurf](/ides/windsurf)
+- [Kilo Code](/ides/kilo-code)
+- [Google Antigravity](/ides/google-antigravity)
+- [OpenAI Codex](/ides/openai-codex)
+
+If your team uses more than one IDE, see the sharing strategies on the [Skills](/skills#managing-skills-across-ides) page.
+
+---
+
+## Explore example factories
+
+Working factories are the fastest way to develop intuition for what good composition looks like. Each example pairs a real application style with the skills, commands, agents, and workflows that support it.
+
+- [Browse example factories →](/examples)
+
+Pick one close to what your team builds, read its components, and steal what fits.
+
+---
+
+## Add the next skill
+
+The first skill you built is the proof of concept. The second, third, and fourth are where the factory starts paying for itself. Same loop every time:
+
+1. Do a task you do often.
+2. Correct the output until it meets your standards.
+3. Ask the assistant to capture the standards as a skill.
+4. Test it in a fresh session.
+5. Commit and share.
+
+Repeat until the assistant produces team-quality output on the tasks that matter to you.

--- a/src/content/docs/getting-started/next-steps.md
+++ b/src/content/docs/getting-started/next-steps.md
@@ -13,11 +13,11 @@ You built a skill. Here is the path most teams follow from there.
 
 The Build Your Software Factory articles go deeper into the practices you just touched on. They are short, hands-on, and build on each other.
 
-- [Article 1 — Do the Work, Then Capture It](/articles/03-do-the-work-then-capture-it/) — The full version of the loop you just ran, with worked corrections.
-- [Article 2 — Test Your Skill in a Clean Room](/articles/04-test-your-skill-in-a-clean-room/) — How to verify a skill works without leaning on context the assistant should not have.
-- [Article 3 — The Retrospective: "Did You Use a Skill?"](/articles/05-the-retrospective-did-you-use-a-skill/) — The single team habit that turns one-off prompts into durable factory components.
-- [Article 4 — Sharpen Your Skill with /skill-optimizer](/articles/06-sharpen-your-skill-with-skill-optimizer/) — Apply authoring best practices to a skill you already have.
-- [Article 5 — A Skill That Holds Up Under Pressure](/articles/07-a-skill-that-holds-up-under-pressure/) — What it looks like when a skill graduates from "works on my machine" to a team standard.
+- [Article 1 — Do the Work, Then Capture It](/articles/03-do-the-work-then-capture-it) — The full version of the loop you just ran, with worked corrections.
+- [Article 2 — Test Your Skill in a Clean Room](/articles/04-test-your-skill-in-a-clean-room) — How to verify a skill works without leaning on context the assistant should not have.
+- [Article 3 — The Retrospective: "Did You Use a Skill?"](/articles/05-the-retrospective-did-you-use-a-skill) — The single team habit that turns one-off prompts into durable factory components.
+- [Article 4 — Sharpen Your Skill with /skill-optimizer](/articles/06-sharpen-your-skill-with-skill-optimizer) — Apply authoring best practices to a skill you already have.
+- [Article 5 — A Skill That Holds Up Under Pressure](/articles/07-a-skill-that-holds-up-under-pressure) — What it looks like when a skill graduates from "works on my machine" to a team standard.
 
 Browse the full list on the [Articles](/articles) page.
 

--- a/src/content/docs/getting-started/quick-start.md
+++ b/src/content/docs/getting-started/quick-start.md
@@ -7,7 +7,7 @@ description: A no-setup walkthrough — pick a task you already do, get the assi
 
 You already have an AI IDE. You already have a task you do often. That is everything you need to build your first factory component.
 
-This walkthrough mirrors the **Do the Work, Then Capture It** pattern from [Article 1](/articles/03-do-the-work-then-capture-it/), distilled to the shortest possible loop. Five minutes from now, you will have a working skill saved in your repository.
+This walkthrough mirrors the **Do the Work, Then Capture It** pattern from [Article 1](/articles/03-do-the-work-then-capture-it), distilled to the shortest possible loop. Five minutes from now, you will have a working skill saved in your repository.
 
 ---
 
@@ -17,7 +17,9 @@ This walkthrough mirrors the **Do the Work, Then Capture It** pattern from [Arti
 - A repeatable task you do often. Anything works: writing a unit test, drafting a PR description, formatting a config file, generating release notes from commits.
 - A repository to save the skill into.
 
-No installs. No configuration.
+No installs needed for this exercise.
+
+> **A note on IDE folders.** This guide saves the skill to `.claude/skills/`, the de facto canonical location across the ecosystem. Claude Code, Cursor, and GitHub Copilot read it directly. Windsurf, Kilo Code, Google Antigravity, and OpenAI Codex look in their own folders and need a one-time copy or symlink before they will load the skill — see the [sharing strategies on the Skills page](/skills#managing-skills-across-ides), or your [IDE guide](/ides), once you finish the exercise.
 
 ---
 
@@ -72,7 +74,10 @@ Start a new session in the same IDE. Give the assistant a similar task — a dif
 
 If the description is good, the assistant will load the skill on its own and follow your standards without further prompting.
 
-If it does not, the description is not specific enough. Edit the `description:` line in `SKILL.md` so it names the *trigger*: when this skill should fire. Test again.
+If it does not, there are two possible reasons:
+
+- **The description is not specific enough.** Edit the `description:` line in `SKILL.md` so it names the *trigger*: when this skill should fire. Test again.
+- **Your IDE does not read `.claude/skills/`.** If you use Windsurf, Kilo Code, Antigravity, or Codex, mirror the skill into your IDE's folder using one of the [sharing strategies on the Skills page](/skills#managing-skills-across-ides), then test again.
 
 ### 7. Celebrate
 
@@ -84,10 +89,10 @@ You just built your first factory component. The next teammate to clone this rep
 
 A `SKILL.md` is a tiny file with YAML frontmatter and a body. The frontmatter declares when the skill should load; the body explains what to do. The assistant reads the description before every task and loads the skill when relevant — that is what makes the standards consistent across the team.
 
-For the deeper version of this loop, with worked corrections and the full reasoning behind each one, read [Article 1: Do the Work, Then Capture It](/articles/03-do-the-work-then-capture-it/).
+For the deeper version of this loop, with worked corrections and the full reasoning behind each one, read [Article 1: Do the Work, Then Capture It](/articles/03-do-the-work-then-capture-it).
 
 ---
 
 ## Where to go next
 
-Continue to [Where to Go Next →](/getting-started/next-steps/) for the recommended path through the rest of the site.
+Continue to [Where to Go Next →](/getting-started/next-steps) for the recommended path through the rest of the site.

--- a/src/content/docs/getting-started/quick-start.md
+++ b/src/content/docs/getting-started/quick-start.md
@@ -1,0 +1,93 @@
+---
+title: Your First Skill in 5 Minutes
+description: A no-setup walkthrough — pick a task you already do, get the assistant's output to your standards, then capture it as your first skill.
+---
+
+# Your First Skill in 5 Minutes
+
+You already have an AI IDE. You already have a task you do often. That is everything you need to build your first factory component.
+
+This walkthrough mirrors the **Do the Work, Then Capture It** pattern from [Article 1](/articles/03-do-the-work-then-capture-it/), distilled to the shortest possible loop. Five minutes from now, you will have a working skill saved in your repository.
+
+---
+
+## What you need
+
+- An AI IDE you already use — Claude Code, Cursor, Copilot, Windsurf, Kilo Code, Antigravity, or Codex.
+- A repeatable task you do often. Anything works: writing a unit test, drafting a PR description, formatting a config file, generating release notes from commits.
+- A repository to save the skill into.
+
+No installs. No configuration.
+
+---
+
+## The five-minute loop
+
+### 1. Open your AI IDE
+
+Open the project where you would normally do this kind of work. The skill will live in this repository so your teammates get it on their next pull.
+
+### 2. Ask the assistant to do the task
+
+Pick something concrete and small. For example:
+
+> Write a unit test for the `calculateInvoiceTotal` function in `src/billing/invoice.ts`.
+
+Or:
+
+> Draft a PR description for the changes on this branch.
+
+Or:
+
+> Format `config/staging.yaml` to match the project's style.
+
+The first answer will be roughly right. It will not match your team's standards.
+
+### 3. Correct the output until it matches your standards
+
+Push back on what is wrong. Be specific. *"Use `describe`/`it`, not `test`. Mock the database with our `createTestDb` helper, not Jest's `jest.mock`. Assert on the return value, not on side effects."*
+
+Iterate until the output is something you would happily commit. Do not compromise. The corrections you make in this step are the standards you are about to capture.
+
+### 4. Ask the assistant to capture what it just learned
+
+Once the output is right, say:
+
+> Create a skill that captures the standards you just followed. Save it to `.claude/skills/my-first-skill/SKILL.md`. Use a clear `description` so the assistant knows when to load it.
+
+The assistant will write a `SKILL.md` containing the rules it followed during the corrections.
+
+### 5. Save and commit
+
+Verify the file exists at `.claude/skills/my-first-skill/SKILL.md`. Read it. Tighten the description if it is vague. Commit it with the rest of your changes.
+
+```bash
+git add .claude/skills/my-first-skill
+git commit -m "Add my-first-skill"
+```
+
+### 6. Test it in a fresh session
+
+Start a new session in the same IDE. Give the assistant a similar task — a different function to test, a different config file to format. Do not mention the skill by name.
+
+If the description is good, the assistant will load the skill on its own and follow your standards without further prompting.
+
+If it does not, the description is not specific enough. Edit the `description:` line in `SKILL.md` so it names the *trigger*: when this skill should fire. Test again.
+
+### 7. Celebrate
+
+You just built your first factory component. The next teammate to clone this repo gets it for free.
+
+---
+
+## What you actually built
+
+A `SKILL.md` is a tiny file with YAML frontmatter and a body. The frontmatter declares when the skill should load; the body explains what to do. The assistant reads the description before every task and loads the skill when relevant — that is what makes the standards consistent across the team.
+
+For the deeper version of this loop, with worked corrections and the full reasoning behind each one, read [Article 1: Do the Work, Then Capture It](/articles/03-do-the-work-then-capture-it/).
+
+---
+
+## Where to go next
+
+Continue to [Where to Go Next →](/getting-started/next-steps/) for the recommended path through the rest of the site.


### PR DESCRIPTION
## Summary
This PR adds a new "Getting started" section to the documentation with three foundational pages that introduce users to software factories and guide them through building their first skill.

## Key Changes
- **New overview page** (`getting-started/introduction/overview.md`) — Introduces the concept of software factories, explains why factory engineering matters, describes the four core components (skills, commands, agents, workflows), and directs users to IDE-specific guides
- **New quick-start guide** (`getting-started/quick-start.md`) — A 5-minute walkthrough for building a first skill with no setup required, following the "Do the Work, Then Capture It" pattern with concrete steps from task selection through testing and committing
- **New next-steps guide** (`getting-started/next-steps.md`) — Recommends the learning path after building the first skill, including links to the article series, IDE-specific setup guides, example factories, and guidance for building additional skills
- **Updated sidebar navigation** (`src/config/sidebar.json`) — Added "Getting started" section as the first item in main navigation, containing the three new pages in logical order

## Implementation Details
- All three pages follow the existing documentation structure with YAML frontmatter (title and description)
- The quick-start guide provides concrete examples (unit tests, PR descriptions, config formatting) to make the concept tangible
- Cross-references between pages create a coherent learning path: overview → quick-start → next-steps → deeper articles
- The sidebar structure places getting started content prominently before the "Factory components" section

https://claude.ai/code/session_01QueNZouPxEoYPTFn7KHZ1U